### PR TITLE
feat(Dialog): dialogコンポーネント実装(立て直し) #29

### DIFF
--- a/components/Dialog.vue
+++ b/components/Dialog.vue
@@ -1,0 +1,63 @@
+<template>
+  <transition name="modal">
+    <div class="modal-mask">
+      <div class="modal-outside" @click="$emit('close')" />
+      <div class="modal-wrapper">
+        <div class="modal">
+          <div class="modal__content">
+            <slot name="content">
+              content
+            </slot>
+          </div>
+          <button class="modal__close" @click="$emit('close')">
+            <slot name="close">
+              close
+            </slot>
+          </button>
+        </div>
+      </div>
+    </div>
+  </transition>
+</template>
+
+<style lang="scss" scoped>
+.modal-mask {
+  position: fixed;
+  z-index: 9998;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, .5);
+  transition: opacity .3s ease;
+}
+
+.modal-outside{
+  position: fixed;
+  height: 100%;
+  width: 100%;
+  z-index: -1;
+}
+
+.modal-wrapper {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translateY(-50%) translateX(-50%);
+}
+
+.modal {
+  width: 300px;
+  background-color: #fff;
+  border-radius: 2px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, .33);
+  transition: all .3s ease;
+}
+
+.modal-leave-active {
+  opacity: 0;
+  .modal {
+  transform: scale(1.1);
+  }
+}
+</style>

--- a/components/Dialog.vue
+++ b/components/Dialog.vue
@@ -1,7 +1,7 @@
 <template>
   <transition name="modal">
-    <div class="modal-mask">
-      <div class="modal-outside" @click="$emit('close')" />
+    <div>
+      <div class="modal-mask" @click="$emit('close')" />
       <div class="modal-wrapper">
         <div class="modal">
           <div class="modal__content">
@@ -23,24 +23,17 @@
 <style lang="scss" scoped>
 .modal-mask {
   position: fixed;
-  z-index: 9998;
+  z-index: 9997;
   top: 0;
   left: 0;
   width: 100%;
   height: 100%;
   background-color: rgba(0, 0, 0, .5);
-  transition: opacity .3s ease;
-}
-
-.modal-outside{
-  position: fixed;
-  height: 100%;
-  width: 100%;
-  z-index: -1;
 }
 
 .modal-wrapper {
-  position: absolute;
+  position: fixed;
+  z-index: 9998;
   top: 50%;
   left: 50%;
   transform: translateY(-50%) translateX(-50%);
@@ -51,13 +44,14 @@
   background-color: #fff;
   border-radius: 2px;
   box-shadow: 0 2px 8px rgba(0, 0, 0, .33);
-  transition: all .3s ease;
 }
 
 .modal-leave-active {
+  transition: .3s ease;
   opacity: 0;
   .modal {
-  transform: scale(1.1);
+    transition: .3s ease;
+    transform: scale(1.1);
   }
 }
 </style>

--- a/package.json
+++ b/package.json
@@ -17,7 +17,9 @@
     "@nuxtjs/axios": "^5.3.6",
     "@nuxtjs/pwa": "^2.6.0",
     "cross-env": "^5.2.0",
+    "node-sass": "^4.11.0",
     "nuxt": "^2.4.0",
+    "sass-loader": "^7.1.0",
     "vue-property-decorator": "^8.1.0"
   },
   "devDependencies": {

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -6,12 +6,26 @@
       <div v-for="(roadmap, index) in roadmaps" :key="index">
         <p>{{ roadmap.title }}</p>
       </div>
+
+      <button @click="showModal = true">
+        Show Modal
+      </button>
+
+      <Dialog v-if="showModal" @close="showModal = false">
+        <template v-slot:content>
+          <p>test</p>
+        </template>
+        <template v-slot:close>
+          閉じる
+        </template>
+      </Dialog>
     </div>
   </section>
 </template>
 
 <script lang="ts">
 import Logo from '~/components/Logo.vue'
+import Dialog from '~/components/Dialog.vue'
 import { Component, Vue } from 'vue-property-decorator'
 
 interface RoadmapCard {
@@ -25,7 +39,8 @@ interface RoadmapCard {
 
 @Component({
   components: {
-    Logo
+    Logo,
+    Dialog
   }
 })
 export default class FeedPage extends Vue {
@@ -40,6 +55,7 @@ export default class FeedPage extends Vue {
       isEditable: 11
     }
   ];
+  showModal = false
 
   mounted() {
     setInterval(() => {

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -42,7 +42,7 @@ interface RoadmapCard {
 @Component({
   components: {
     Logo,
-    Dialog
+    Dialog,
     Favorite
   }
 })

--- a/test/Dialog.spec.js
+++ b/test/Dialog.spec.js
@@ -1,0 +1,43 @@
+import { mount } from '@vue/test-utils'
+import Dialog from '@/components/Dialog.vue'
+
+describe('Dialog', () => {
+  test('is a Vue instance', () => {
+    const wrapper = mount(Dialog)
+    expect(wrapper.isVueInstance()).toBeTruthy()
+  })
+
+  test('closeクリックした後閉じる', () => {
+    const wrapper = mount(Dialog)
+    wrapper.find('.modal__close').trigger('click')
+    setTimeout(() => {
+      expect(wrapper.find('.modal-mask')).toBefalsy()
+    }, 500)
+  })
+
+  test('モーダルの外をクリックした後閉じる', () => {
+    const wrapper = mount(Dialog)
+    wrapper.find('.modal-outside').trigger('click')
+    setTimeout(() => {
+      expect(wrapper.find('.modal-mask')).toBefalsy()
+    }, 500)
+  })
+
+  test('content slotの内容が反映される', () => {
+    const wrapper = mount(Dialog, {
+      slots: {
+        content: 'コンテント'
+      }
+    })
+    expect(wrapper.find('.modal__content').text()).toBe('コンテント')
+  })
+
+  test('close slotの内容が反映される', () => {
+    const wrapper = mount(Dialog, {
+      slots: {
+        close: '閉じる'
+      }
+    })
+    expect(wrapper.find('.modal__close').text()).toBe('閉じる')
+  })
+})


### PR DESCRIPTION
fixed #29 

dialogコンポーネントの見た目に変化無いので前の画像のままです。
![screencapture-localhost-3000-2019-04-06-07_36_34](https://user-images.githubusercontent.com/32005523/55660021-31036200-583f-11e9-827a-e3118912969a.png)

ブランチ名修正してプルリクエスト立て直しました。
ご確認よろしくお願いします。

## 使用方法

モーダル表示自体は親コンポーネント側でv-ifを使いボタンなどで切り替えます。

```html
      <Dialog v-if="showModal" @close="showModal = false">
        <template v-slot:content>
          <p>test</p>
        </template>
        <template v-slot:close>
          閉じる
        </template>
      </Dialog>
```

名前|タイプ|型|説明
---|---|---|---
close|event|boolean|モーダルクローズイベント
content|slot|any|モーダルの中身
close|slot|any|closeボタン